### PR TITLE
updater fixes

### DIFF
--- a/R/Optimal_Rule_Q_learning.R
+++ b/R/Optimal_Rule_Q_learning.R
@@ -44,9 +44,9 @@ Optimal_Rule_Q_learning <- R6Class(
       private$.cf_tasks <- cf_tasks
     },
 
-    rule = function(tmle_task) {
+    rule = function(tmle_task, fold_number="full") {
       # Get Q(a,W) for each level of A, all folds
-      blip_fin <- sapply(private$.cf_tasks, private$.likelihood$get_likelihood, "Y", -1)
+      blip_fin <- sapply(private$.cf_tasks, private$.likelihood$get_likelihood, "Y", fold_number)
 
       if (private$.maximize) {
         rule_index <- max.col(blip_fin)

--- a/R/tmle3_cv_Update.R
+++ b/R/tmle3_cv_Update.R
@@ -42,5 +42,11 @@ tmle3_cv_Update <- R6Class(
       ED <- colMeans(ICs)
       return(max(abs(ED)) < ED_criterion)
     }
+  ),
+  active = list(
+    
+    cvtmle = function(){
+      return(TRUE)
+    }
   )
 )


### PR DESCRIPTION
Fixes related to breaking changes in `tmle3`. Sorry for the late changes.

* make `tmle3_Update_bound` inherit from `tmle3_Update`
* Use new scaling logic in `tmle3_Update_bound`
* add method to both custom updaters to report `cvtmle` TRUE/FALSE
* make Q learning rule accept `fold_number` argument like revere rule
